### PR TITLE
imporvements: css 초기화 파일 불필요한 설정 정리 및 header, footer margin 정리

### DIFF
--- a/css/footer.css
+++ b/css/footer.css
@@ -5,8 +5,7 @@ footer {
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    /* margin-top: 60px; */
-    /* margin-bottom: 0; */
+    margin-top: 200px;
     background-color: rgb(67, 67, 67);
     
 }
@@ -18,7 +17,6 @@ footer {
     flex-direction: row;
     align-items: center;
     justify-content: center;
-    margin-bottom: 10px;
 }
 
 .footer_row1 {

--- a/css/header.css
+++ b/css/header.css
@@ -22,7 +22,6 @@ header {
     justify-content: space-between;
 }
 
-
 .header_wrapper_right {
     width: 400px;
     display: flex;
@@ -36,14 +35,9 @@ header {
     text-decoration: none;
 }
 
-
-
 .header_wrapper_bottom {
     width: 90vw;
-    /* display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center; */
+    margin-bottom: 20px;
 }
 
 .header_line {
@@ -54,11 +48,12 @@ header {
     margin-bottom: 20px;
 }
 
-
 .header_bottom_content {
     text-align: center;
 }
 
-
-
-
+.header_game_play_button {
+    cursor: pointer;
+    background-color: blueviolet;
+    color: white;
+}

--- a/css/styles.css
+++ b/css/styles.css
@@ -2,9 +2,9 @@
 @import "main.css";
 @import "footer.css";
 @import "puzzle.css";
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
+/* 
+html, body, div, span, applet, object, iframe, */
+/* h1, h2, h3, h4, h5, h6, p, blockquote, pre, */
 a, abbr, acronym, address, big, cite, code,
 del, dfn, em, img, ins, kbd, q, s, samp,
 small, strike, strong, sub, sup, tt, var,
@@ -25,7 +25,7 @@ time, mark, audio, video {
 }
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure, 
-footer, header, hgroup, menu, nav, section {
+/* footer,*/ header, hgroup, menu, nav, section {
 	display: block;
 }
 body {


### PR DESCRIPTION
reset.css 초기화 태그 정리
1. html, body, div, h1 ~ h6 태그에 margin:0, padding:0 적용되 있는것 삭제
(여백과 패딩이 잡히지 않아 header와 footer를 정렬하는데 힘들었는데 reset.css 파일에 원인이 있어던것을 알게 되었다)

header, footer 정리
2. header.css와 footer.css에 margin을 수정